### PR TITLE
Added a cloud ignore file

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,0 +1,25 @@
+# This file specifies files that are *not* uploaded to Google Cloud Platform
+# using gcloud. It follows the same syntax as .gitignore, with the addition of
+# "#!include" directives (which insert the entries of the given .gitignore-style
+# file at that point).
+#
+# For more information, run:
+#   $ gcloud topic gcloudignore
+#
+.gcloudignore
+# If you would like to upload your .git directory, .gitignore file or files
+# from your .gitignore file, remove the corresponding line
+# below:
+.git
+.gitignore
+.idea
+
+node_modules
+!include:.gitignore
+!dist/
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/sdks
+!.yarn/versions


### PR DESCRIPTION
The default behavior is to use the .gitignore file which tells the GCF deployment to ignore the `dist` folder so this file precisely m, mentions to keep it.